### PR TITLE
Remove unused variable f in temp.from.geom

### DIFF
--- a/spatial-data.Rmd
+++ b/spatial-data.Rmd
@@ -272,7 +272,6 @@ can be modeled, universally anywhere on globe, by using the following formula:
 ```{r}
 temp.from.geom <- function(fi, day, a=30.419375, 
                            b=-15.539232, elev=0, t.grad=0.6) {
-  f = ifelse(fi==0, 1e-10, fi)
   costeta = cos( (day-18 )*pi/182.5 + 2^(1-sign(fi) ) *pi) 
   cosfi = cos(fi*pi/180 )
   A = cosfi


### PR DESCRIPTION
In section 1.7, in the definition of the temp.from.geom function, there is the variable f defined, I guess, to avoid the ambiguity of sign in case fi is 0, but then not used. It is not really impacting but a bit confusing, and since sign(0) return 0 I think it is even more reasonable to show a perfectly flat curve.