### PR TITLE
Mismatch between the values shown/computed

### DIFF
--- a/spatial-interpolation.Rmd
+++ b/spatial-interpolation.Rmd
@@ -177,9 +177,8 @@ spatial Cross-Validation using:
 summary(m@spModel$learner.model$super.model$learner.model)
 ```
 
-Which shows that the model explains about 65% of variability in target variable 
-and that `regr.ranger` learner [@wright2017ranger] is the strongest learner. Average 
-mapping error RMSE = 213, hence the models is somewhat more accurate than if we 
+Which shows that `regr.ranger` learner [@wright2017ranger] is the strongest learner, and also, by observing the
+residual standard error, that the models is somewhat more accurate than if we 
 only used buffer distances.
 
 To predict values at all grids we use:


### PR DESCRIPTION
I noticed that the result of summary(m@spModel$learner.model$super.model$learner.model) in GitHub does not match the one described (that instead match with the one obtained). Maybe the cause of this should be investigated, or in any case write a more conservative sentence that does not mention precise values.